### PR TITLE
Updated package.json and wrote an introductory README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node.js and dotenv files
+node_modules
+.env
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+
+# VisualStudio Code project files
+.vscode/*
+
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-FCC Mongo & Mongoose Challenges
-===============================
+FCC MongoDB & Mongoose Challenges
+=================================
+
+This is the repository for the freeCodeCamp [MongoDB and Mongoose Challenges](https://learn.freecodecamp.org/apis-and-microservices/mongodb-and-mongoose).  
+If you haven't worked with **git** before, you might first want to read a few   
+[resources](http://try.github.io/) about it, or go the [Glitch](https://glitch.com/) 
+way as described on the above mentioned challenge introduction page.
+
+To clone this Repository, go to a directory of your choice and enter:
+```
+git clone https://github.com/freeCodeCamp/boilerplate-mongomongoose.git
+cd boilerplatform-mongomongoose
+```
+But to be able to import it in Glitch or the coding platform of your choice,  
+you have to [create your own Repository on GitHub](https://help.github.com/articles/creating-a-new-repository/).  
+But before you are able to push to it, you have to remove the remote origin of
+freeCodeCamp,   
+rename the "gomix" branch to "master" and delete the gomix branch
+to have a clutter free Repository:
+```
+git remote remove origin
+git branch -m master
+git branch -d gomix
+```
+Then follow the steps outlined in **...or push an existing repository from the command line**  
+on the **Quick setup** screen, e.g.:
+```
+git remote add origin git@github.com:<yourname>/<your_repository>.git
+git push -u origin master
+```
+
+Now you should have a fully functional Repository you can import to a coding platform.  
+But to develop locally, there is one more step necessary, run:
+```
+npm install
+```
+Now create a _private_ ```.env``` (it won't get pushed) file where you can put 
+your ```MONGO_URI=``` and you are good to go.   
+Don't forget to commit and push your changes after each challenge step (and, 
+depending on your coding platform      
+of choice, reimport it there), so freeCodeCamp is able to test your results!  
+
+*Happy Coding!*
+

--- a/myApp.js
+++ b/myApp.js
@@ -2,6 +2,8 @@
 * 3. FCC Mongo & Mongoose Challenges
 * ==================================
 ***********************************************/
+/** Required for local development*/
+require('dotenv').config();
 
 /** # MONGOOSE SETUP #
 /*  ================== */

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"body-parser": "^1.15.2"
 	},
 	"engines": {
-		"node": "4.4.5"
+		"node": "8.x"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
 		"start": "node server.js"
 	},
 	"dependencies": {
-		"express": "^4.16.3",
-		"body-parser": "^1.18.3"
+		"body-parser": "^1.18.3",
+		"dotenv": "^6.0.0",
+		"express": "^4.16.3"
 	},
 	"engines": {
 		"node": "8.x"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 		"start": "node server.js"
 	},
 	"dependencies": {
-		"express": "^4.12.4",
-		"body-parser": "^1.15.2"
+		"express": "^4.16.3",
+		"body-parser": "^1.18.3"
 	},
 	"engines": {
 		"node": "8.x"


### PR DESCRIPTION
As Glitch was always complaining about "4.4.5" not being an available Node.js version, 
and (developing locally) yarn would strike completely, I changed the following:

- [x] added `.gitignore` to prevent pushing `node_modules` and IDE files, as well as `.env`
- [x] updated Node.js in package.json to 8.x
- [x] updated **express** & **body-parser** to latest stable versions (^4.16.3 & ^1.18.3)
- [x] added **dotenv** package for local development
- [x] added a meaningful introduction and warning to README.md

These changes won't break anything but might stop irritating students with error messages
when starting the challenges. Should this PR be accepted, I'd very much like to do the same
with the other challenges' and projects' Boilerplate Repositories : ).

One more thought:
While doing the challenges and later the projects, having installed the **mongodb** and **mongoose**
packages triggered a lot of _deprecation warnings_ on glitch, as well as locally (using the latest stable
versions of the packages). I'd be happy to look through the server code, too.

Edits: Typos.