### PR TITLE
fix: Remove engine from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
         "dotenv": "^8.2.0",
         "express": "^4.12.4"
     },
-    "engines": {
-        "node": "12.*"
-    },
     "repository": {
         "type": "git",
         "url": "https://github.com/freeCodeCamp/boilerplate-mongomongoose.git"


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

Removes the `engine` field from the `package.json` per http://github.com/freeCodeCamp/freeCodeCamp/issues/40365