### PR TITLE
fix: changed server.js file to address mongoose collection.remove, collection.count deprecated warnings

### DIFF
--- a/server.js
+++ b/server.js
@@ -108,7 +108,7 @@ router.get("/create-and-save-person", function (req, res, next) {
 
 const createPeople = require("./myApp.js").createManyPeople;
 router.post("/create-many-people", function (req, res, next) {
-  Person.remove({}, function (err) {
+  Person.deleteMany({}, function (err) {
     if (err) {
       return next(err);
     }
@@ -130,7 +130,7 @@ router.post("/create-many-people", function (req, res, next) {
           return next(err);
         }
         res.json(pers);
-        Person.remove().exec();
+        Person.deleteMany().exec();
       });
     });
   });
@@ -155,7 +155,7 @@ router.post("/find-all-by-name", function (req, res, next) {
         return next({ message: "Missing callback argument" });
       }
       res.json(data);
-      Person.remove().exec();
+      Person.deleteMany().exec();
     });
   });
 });
@@ -272,7 +272,7 @@ router.post("/find-one-update", function (req, res, next) {
 
 const removeOne = require("./myApp.js").removeById;
 router.post("/remove-one-person", function (req, res, next) {
-  Person.remove({}, function (err) {
+  Person.deleteMany({}, function (err) {
     if (err) {
       return next(err);
     }
@@ -295,7 +295,7 @@ router.post("/remove-one-person", function (req, res, next) {
             return next({ message: "Missing callback argument" });
           }
           console.log(data);
-          Person.count(function (err, cnt) {
+          Person.estimatedDocumentCount(function (err, cnt) {
             if (err) {
               return next(err);
             }
@@ -315,7 +315,7 @@ router.post("/remove-one-person", function (req, res, next) {
 
 const removeMany = require("./myApp.js").removeManyPeople;
 router.post("/remove-many-people", function (req, res, next) {
-  Person.remove({}, function (err) {
+  Person.deleteMany({}, function (err) {
     if (err) {
       return next(err);
     }
@@ -336,7 +336,7 @@ router.post("/remove-many-people", function (req, res, next) {
             console.log("Missing `done()` argument");
             return next({ message: "Missing callback argument" });
           }
-          Person.count(function (err, cnt) {
+          Person.estimatedDocumentCount(function (err, cnt) {
             if (err) {
               return next(err);
             }
@@ -369,7 +369,7 @@ router.post("/query-tools", function (req, res, next) {
   let t = setTimeout(() => {
     next({ message: "timeout" });
   }, TIMEOUT);
-  Person.remove({}, function (err) {
+  Person.deleteMany({}, function (err) {
     if (err) {
       return next(err);
     }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #34833

<!-- Feel free to add any additional description of changes below this line -->

I ran into the same warning as mentioned in https://github.com/freeCodeCamp/freeCodeCamp/issues/34833, along with a similar waning about count(). These are the changes I made in my own replit to silence the warnings, and I thought I'd share them in case they're helpful.

remove() to deleteMany() per https://mongoosejs.com/docs/deprecations.html#remove
count() to estimatedDocumentCount() per https://mongoosejs.com/docs/deprecations.html#count

I was going to test this with Mongoose 4.13.21 and 3.8.40, however I couldn't get the app to connect to mongodb atlas using the URI starting with mongodb+srv. After some digging, it appears you have to use Mongoose 5 to use mongodb atlas, so no one should be using <v5 to follow this tutorial anyway: https://github.com/Automattic/mongoose/issues/9326

running the microservices mongodb/mongoose tests on my replit, before:

```
> node server.js

Your app is listening on port 3000
GET
GET
GET
POST
GET
OPTIONS
POST
(node:186) DeprecationWarning: collection.remove is deprecated. Use deleteOne, deleteMany, or bulkWrite instead.
POST
POST
GET
POST
POST
POST
{
  favoriteFoods: [ 'apples' ],
  _id: 60dabbb58708d000ba6272da,
  name: 'Jason Bourne',
  age: 36,
  __v: 0
}
(node:186) DeprecationWarning: collection.count is deprecated, and will be removed in a future version. Use Collection.countDocuments or Collection.estimatedDocumentCount instead
{
  favoriteFoods: [ 'apples' ],
  _id: 60dabbb58708d000ba6272da,
  name: 'Jason Bourne',
  age: 36,
  __v: 0,
  count: 0
}
OPTIONS
POST
OPTIONS
POST
```

after:
```
> node server.js

Your app is listening on port 3000
GET
GET
GET
POST
GET
OPTIONS
POST
POST
POST
GET
POST
POST
POST
{
  favoriteFoods: [ 'apples' ],
  _id: 60dabdb42b521600fef411df,
  name: 'Jason Bourne',
  age: 36,
  __v: 0
}
{
  favoriteFoods: [ 'apples' ],
  _id: 60dabdb42b521600fef411df,
  name: 'Jason Bourne',
  age: 36,
  __v: 0,
  count: 0
}
OPTIONS
POST
OPTIONS
POST
```